### PR TITLE
chore: removed the OpenSSL_add_all_algorithms 

### DIFF
--- a/token_signature.go
+++ b/token_signature.go
@@ -191,10 +191,6 @@ func verifyCertificates(root, inter, leaf *x509.Certificate) error {
 	return nil
 }
 
-func init() {
-	C.OpenSSL_add_all_algorithms_func()
-}
-
 // verifyPKCS7Signature verifies that the signature was produced by the leaf
 // certificate contained in the given PKCS7 struct
 func (t PKPaymentToken) verifyPKCS7Signature(p7 *C.PKCS7) error {
@@ -205,6 +201,7 @@ func (t PKPaymentToken) verifyPKCS7Signature(p7 *C.PKCS7) error {
 	//
 	//     return errors.Wrap(err, "invalid signature")
 	// }
+	//C.OpenSSL_add_all_algorithms_func()
 
 	//defer C.EVP_cleanup()
 	signedDataBio := newBIOBytes(t.signedData())

--- a/token_signature.go
+++ b/token_signature.go
@@ -191,6 +191,10 @@ func verifyCertificates(root, inter, leaf *x509.Certificate) error {
 	return nil
 }
 
+func init() {
+	C.OpenSSL_add_all_algorithms_func()
+}
+
 // verifyPKCS7Signature verifies that the signature was produced by the leaf
 // certificate contained in the given PKCS7 struct
 func (t PKPaymentToken) verifyPKCS7Signature(p7 *C.PKCS7) error {
@@ -202,7 +206,6 @@ func (t PKPaymentToken) verifyPKCS7Signature(p7 *C.PKCS7) error {
 	//     return errors.Wrap(err, "invalid signature")
 	// }
 
-	C.OpenSSL_add_all_algorithms_func()
 	//defer C.EVP_cleanup()
 	signedDataBio := newBIOBytes(t.signedData())
 	defer signedDataBio.Free()
@@ -269,6 +272,7 @@ func (t PKPaymentToken) verifySigningTime(p7 *C.PKCS7) error {
 // extractSigningTime returns the time of signing from a PKCS7 struct
 func (t PKPaymentToken) extractSigningTime(p7 *C.PKCS7) (time.Time, error) {
 	signerInfoList := C.PKCS7_get_signer_info(p7)
+
 	if signerInfoList == nil {
 		return time.Time{},
 			errors.New("openssl error when extracting signer information")
@@ -315,7 +319,7 @@ func (t PKPaymentToken) extractSigningTime(p7 *C.PKCS7) (time.Time, error) {
 func union(union [8]byte) unsafe.Pointer {
 	dBuf := bytes.NewBuffer(union[:])
 	var ptr uint64
-	binary.Read(dBuf, binary.LittleEndian, &ptr)
+	_ = binary.Read(dBuf, binary.LittleEndian, &ptr)
 	return unsafe.Pointer(uintptr(ptr))
 }
 


### PR DESCRIPTION
https://www.openssl.org/docs/man1.1.0/man3/OpenSSL_add_all_algorithms.html
Looks from the openssl version 1.1 doesn't need anymore and it was called every verify signature
