### PR TITLE
Add China compatibility to Apple session endpoint

### DIFF
--- a/session.go
+++ b/session.go
@@ -59,7 +59,7 @@ func checkSessionURL(location string) error {
 	if err != nil {
 		return errors.Wrap(err, "error parsing the URL")
 	}
-	hostReg := regexp.MustCompile("^apple-pay-gateway(-.+)?.apple.com$")
+	hostReg := regexp.MustCompile("^(cn-)?apple-pay-gateway(-.+)?.apple.com$")
 	if !hostReg.MatchString(u.Host) {
 		return errors.New("invalid host")
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -105,6 +105,15 @@ func TestCheckSessionURL(t *testing.T) {
 		Convey("apple.com does not work", func() {
 			So(checkSessionURL("https://apple.com"), ShouldNotBeNil)
 		})
+
+		Convey("attacking attempt should not work", func() {
+			So(checkSessionURL("https://attacker.com/cn-apple-pay-gateway.apple.com"), ShouldNotBeNil)
+		})
+
+		Convey("attacking attempt 2 should not work", func() {
+			So(checkSessionURL("https://attacker.com?cn-apple-pay-gateway.apple.com"), ShouldNotBeNil)
+		})
+
 	})
 
 	Convey("Wrong scheme", t, func() {
@@ -116,6 +125,10 @@ func TestCheckSessionURL(t *testing.T) {
 	Convey("Valid cases", t, func() {
 		Convey("Right domain with right scheme works", func() {
 			So(checkSessionURL("https://apple-pay-gateway.apple.com"), ShouldBeNil)
+		})
+
+		Convey("China specific domain works", func() {
+			So(checkSessionURL("https://cn-apple-pay-gateway.apple.com"), ShouldBeNil)
 		})
 
 		Convey("Alternative gateway URLs work", func() {


### PR DESCRIPTION
This pull request change the regex to add Apple Pay domain for China.
[Implementation](https://go.dev/play/p/6YQqupS8llD)